### PR TITLE
Only remove and re-add models that have new sort positions.

### DIFF
--- a/backbone-sorted-collection.js
+++ b/backbone-sorted-collection.js
@@ -21,17 +21,20 @@ function lookupIterator(value) {
   return _.isFunction(value) ? value : function(obj){ return obj.get(value); };
 }
 
-function onAdd(model) {
-  var index;
+function modelInsertIndex(model) {
   if (!this._comparator) {
-    index = this._superset.indexOf(model);
+    return this._superset.indexOf(model);
   } else {
     if (!this._reverse) {
-      index = _.sortedIndex(this._collection.toArray(), model, lookupIterator(this._comparator));
+      return _.sortedIndex(this._collection.toArray(), model, lookupIterator(this._comparator));
     } else {
-      index = reverseSortedIndex(this._collection.toArray(), model, lookupIterator(this._comparator));
+      return reverseSortedIndex(this._collection.toArray(), model, lookupIterator(this._comparator));
     }
   }
+}
+
+function onAdd(model) {
+  var index = modelInsertIndex.call(this, model);
   this._collection.add(model, { at: index });
 }
 
@@ -42,7 +45,7 @@ function onRemove(model) {
 }
 
 function onChange(model) {
-  if (this.contains(model)) {
+  if (this.contains(model) && this._collection.indexOf(model) !== modelInsertIndex.call(this, model)) {
     this._collection.remove(model);
     onAdd.call(this, model);
   }


### PR DESCRIPTION
When a model gets changed, it is removed and re-added to the proxy collection to enforce proper order in the proxy collection. However, this is done on every change event, not just the ones that would alter the collection order. This change only removes and re-inserts the model if it would have a new position based on the change.
